### PR TITLE
Widget permutation builder

### DIFF
--- a/src/home/controller/home-controller.coffee
+++ b/src/home/controller/home-controller.coffee
@@ -2,9 +2,9 @@ angular.module 'app.home'
 
 .controller 'HomeController', (
   $scope
+  widgetStore
 ) ->
-  $scope.submit = ($widgets) ->
-    console.log 'look at all these widgets we built!'
-    console.table _.map $widgets, (widget) -> return widget.attributes
+  $scope.widgets = widgetStore.getWidgets()
 
-    # Implement your AJAX call here
+  $scope.deleteWidget = (index) ->
+    widgetStore.deleteWidget index

--- a/src/home/controller/home-controller.coffee
+++ b/src/home/controller/home-controller.coffee
@@ -4,3 +4,9 @@ angular.module 'app.home'
   $scope
 ) ->
   console.log 'we hood now'
+
+  $scope.submit = ($widgets) ->
+    console.log 'look at all these widgets we built!'
+    console.table $widgets
+
+    # Implement your AJAX call here

--- a/src/home/controller/home-controller.coffee
+++ b/src/home/controller/home-controller.coffee
@@ -3,10 +3,8 @@ angular.module 'app.home'
 .controller 'HomeController', (
   $scope
 ) ->
-  console.log 'we hood now'
-
   $scope.submit = ($widgets) ->
     console.log 'look at all these widgets we built!'
-    console.table $widgets
+    console.table _.map $widgets, (widget) -> return widget.attributes
 
     # Implement your AJAX call here

--- a/src/home/home.coffee
+++ b/src/home/home.coffee
@@ -1,4 +1,5 @@
 angular.module 'app.home', [
+  'app.widget'
   'ui.router'
 ]
 

--- a/src/home/home.jade
+++ b/src/home/home.jade
@@ -1,3 +1,9 @@
-.container.text-center
-  h1 Home
-  p.lead Some stuff
+.container-fluid
+  .row
+    .col-md-12
+      h1 Home
+      p.lead Some stuff
+
+  kc-widget-form(
+    on-submit = "submit($widgets)"
+  )

--- a/src/home/home.jade
+++ b/src/home/home.jade
@@ -1,14 +1,5 @@
 .container-fluid
   .row
-    .col-md-6.col-md-offset-3
-      .jumbotron.text-center(ng-if="widgets.length === 0")
-        p.lead You haven't created any widgets yet!
-
-        a.btn.btn-default.btn-lg(
-          ui-sref = "widget-builder"
-        ) Get Started
-
-  .row(ng-if="widgets.length > 0")
     .col-lg-3.col-md-4.col-sm-6(
       ng-repeat = "widget in widgets track by $index"
     )
@@ -23,3 +14,19 @@
 
         h4 Description
         p {{widget.description}}
+
+    .col-lg-3.col-md-4.col-sm-6
+      .well.text-center
+        div(ng-switch="widgets.length")
+          p.lead(
+            ng-switch-when = "0"
+          ) You haven't created any widgets yet!
+
+          p.lead(
+            ng-switch-default
+          ) Create More Widgets
+
+        a.btn.btn-default.btn-lg(
+          ui-sref = "widget-builder"
+        )
+          span.glyphicon.glyphicon-plus

--- a/src/home/home.jade
+++ b/src/home/home.jade
@@ -1,9 +1,25 @@
 .container-fluid
   .row
-    .col-md-12
-      h1 Home
-      p.lead Some stuff
+    .col-md-6.col-md-offset-3
+      .jumbotron.text-center(ng-if="widgets.length === 0")
+        p.lead You haven't created any widgets yet!
 
-  kc-widget-form(
-    on-submit = "submit($widgets)"
-  )
+        a.btn.btn-default.btn-lg(
+          ui-sref = "widget-builder"
+        ) Get Started
+
+  .row(ng-if="widgets.length > 0")
+    .col-lg-3.col-md-4.col-sm-6(
+      ng-repeat = "widget in widgets track by $index"
+    )
+      .well
+        button.close(
+          type = "button"
+          ng-click = "deleteWidget($index)"
+        ) &times;
+
+        h4 Name
+        p {{widget.name}}
+
+        h4 Description
+        p {{widget.description}}

--- a/src/index.jade
+++ b/src/index.jade
@@ -12,6 +12,19 @@ html(
     link(rel="stylesheet", href="/css/app.css")
 
   body
+    nav.navbar.navbar-inverse.navbar-fixed-top
+      .container-fluid
+        .navbar-header
+          a.navbar-brand(ui-sref="home") The Widget Factory
+
+        .navbar-collapse.navbar-right
+          ul.nav.navbar-nav
+            li(ui-sref-active="active")
+              a(ui-sref="home") Home
+
+            li(ui-sref-active = "active")
+              a(ui-sref="widget-builder") Widget Builder
+
     div(ui-view="main")
 
     each script in scripts

--- a/src/permutation/_permutable-input.jade
+++ b/src/permutation/_permutable-input.jade
@@ -1,15 +1,25 @@
 form.form-group(
   ng-submit = "submit()"
+  name = "form"
+  ng-class = "{ 'has-error': form.$invalid && form.value.$touched }"
 )
-  label(ng-transclude)
+  label.control-label(
+    for = "{{input_id}}"
+  )
+    span(ng-transclude)
+    span(ng-if="state.is_required") *
 
   .input-group
     input.form-control(
+      id = "{{input_id}}"
+      name = "value"
       type = "text"
       ng-model = "state.value"
+      ng-required = "isRequired()"
     )
 
     .input-group-btn
       button.btn.btn-default(
         type = "submit"
+        ng-disabled = "isDisabled()"
       ) Add

--- a/src/permutation/_permutable-input.jade
+++ b/src/permutation/_permutable-input.jade
@@ -1,0 +1,15 @@
+form.form-group(
+  ng-submit = "submit()"
+)
+  label(ng-transclude)
+
+  .input-group
+    input.form-control(
+      type = "text"
+      ng-model = "state.value"
+    )
+
+    .input-group-btn
+      button.btn.btn-default(
+        type = "submit"
+      ) Add

--- a/src/permutation/directive/permutable-attributes-directive.coffee
+++ b/src/permutation/directive/permutable-attributes-directive.coffee
@@ -1,0 +1,104 @@
+###
+@name kcPermutableAttributes
+@description
+A thin controller that manages a `permutable_attributes` data structure, used to
+generate permutations of a resource. Exposes an API for consumption by
+kcPermutableInput and kcPermutableImage child directives.
+
+@param {Object} permutable_attributes
+@param {Callback} buildPermutations
+
+@returns {KcPermutableAttributesController}
+
+@callback buildPermutations
+@description
+Handler called to generate permutations from the `permutable_attributes` object
+when a new attribute is added.
+
+@example
+```coffee
+$scope.permutable_attributes =
+  name: []
+  url: []
+  thumbnail: []
+```
+
+```jade
+form(
+  name = "widget_form"
+  ng-submit = "submit()"
+)
+  label Permutation Group Name
+  input(
+    type = "text"
+    name = "permutation_group_name"
+    ng-model = "state.common_attributes.permutation_group_name"
+  )
+
+  kc-permutable-attributes(
+    permutable-attributes = "state.permutable_attributes"
+    build-permutations = "buildPermutations(permutable_attributes)"
+  )
+    kc-permutable-input(
+      name = "name"
+      type = "text"
+      required
+    ) Name
+
+    kc-permutable-image(
+      name = "thumbnail"
+      type = "image"
+    ) Thumbnail
+
+  button(
+    type = "submit"
+  ) Submit
+```
+###
+
+angular.module 'app.permutation'
+.directive 'kcPermutableAttributes', ->
+  restrict: 'E'
+  controller: 'KcPermutableAttributesController'
+  scope:
+    permutable_attributes: '=permutableAttributes'
+    buildPermutations: '&buildPermutations'
+
+.controller 'KcPermutableAttributesController', (
+  $scope
+) ->
+  do setPermutableAttributes = =>
+    @permutable_attributes = $scope.permutable_attributes
+
+  # Reset our reference to permutable attributes object when it changes
+  $scope.$watch 'permutable_attributes', (new_value, old_value) ->
+    setPermutableAttributes() unless new_value is old_value
+
+  ###
+  @name addAttribute
+  @description
+  Adds a permutable attribute
+
+  @returns {Boolean} - Whether attribute was added or not
+  ###
+
+  @addAttribute = (key, value) ->
+    bucket = $scope.permutable_attributes[key]
+
+    throw Error "Invalid: key '#{key}'" unless bucket?
+
+    if _.contains bucket, value
+      console.warn "'#{value}' already entered."
+
+      return false
+
+    # Add the value to permute against
+    bucket.push value
+
+    # And generate the permutations
+    $scope.buildPermutations
+      permutable_attributes: $scope.permutable_attributes
+
+    return true
+
+  return this

--- a/src/permutation/directive/permutable-input-directive.coffee
+++ b/src/permutation/directive/permutable-input-directive.coffee
@@ -1,0 +1,29 @@
+###
+@name kcPermutableInput
+
+@param {String} name - Permutable attribute key
+###
+
+angular.module 'app.permutation'
+.directive 'kcPermutableInput', ->
+  require: '^kcPermutableAttributes'
+  restrict: 'E'
+  templateUrl: '/permutation/_permutable-input.html'
+  transclude: true
+
+  scope:
+    name: '@name'
+
+  link: (scope, element, attrs, kcPermutableAttributesController) ->
+    scope.state =
+      value: ''
+      is_required: attrs.required?
+
+    scope.submit = ->
+      is_added = kcPermutableAttributesController.addAttribute(
+        scope.name
+        scope.state.value
+      )
+
+      if is_added
+        scope.state.value = ''

--- a/src/permutation/directive/permutable-input-directive.coffee
+++ b/src/permutation/directive/permutable-input-directive.coffee
@@ -15,9 +15,19 @@ angular.module 'app.permutation'
     name: '@name'
 
   link: (scope, element, attrs, kcPermutableAttributesController) ->
+    # Ensure input IDs are unique
+    scope.input_id = _.uniqueId 'permutatable_input_'
+
     scope.state =
       value: ''
       is_required: attrs.required?
+
+    scope.isDisabled = ->
+      return _.isEmpty scope.state.value
+
+    scope.isRequired = ->
+      return attrs.required? and
+        kcPermutableAttributesController.permutable_attributes[scope.name].length is 0
 
     scope.submit = ->
       is_added = kcPermutableAttributesController.addAttribute(

--- a/src/permutation/permutation.coffee
+++ b/src/permutation/permutation.coffee
@@ -1,0 +1,1 @@
+angular.module 'app.permutation', []

--- a/src/permutation/service/permutation-factory.coffee
+++ b/src/permutation/service/permutation-factory.coffee
@@ -17,22 +17,26 @@ angular.module 'app.permutation'
     permutations = []
 
     recurse = (keys, payload = {}, position = 0) ->
+      # We've finished constructing the permutation, exit call stack
+      if position is keys.length
+        permutation = _.clone payload
+        callback? permutation
+        permutations.push permutation
+
+        return
+
+      # Grab the current key
       key = keys[position]
 
       # There are no values for this attribute, skip it
       if permutable_attributes[key].length is 0
-        if position < keys.length - 1
-          recurse keys, payload, position + 1
-        else
-          permutations.push _.clone payload
+        recurse keys, payload, position + 1
 
-      for value in permutable_attributes[key]
-        payload[key] = value
+      # Otherwise, recurse for each possible value of this attribute
+      else
+        for value in permutable_attributes[key]
+          payload[key] = value
 
-        if position is keys.length - 1
-          permutations.push _.clone payload
-
-        else
           recurse keys, payload, position + 1
 
     recurse Object.keys permutable_attributes

--- a/src/permutation/service/permutation-factory.coffee
+++ b/src/permutation/service/permutation-factory.coffee
@@ -1,0 +1,17 @@
+angular.module 'app.permutation'
+.factory 'permutationFactory', ->
+
+  ###
+  @name permute
+  @description
+  Generates permutations from a permutable_attributes object.
+
+  @param {Object} permutable_attributes
+  @param {Callback} callback
+
+  @callback callback
+  @param {Object} permutation
+  ###
+
+  permute: (permutable_attributes, callback) ->
+    # TODO

--- a/src/permutation/service/permutation-factory.coffee
+++ b/src/permutation/service/permutation-factory.coffee
@@ -14,4 +14,27 @@ angular.module 'app.permutation'
   ###
 
   permute: (permutable_attributes, callback) ->
-    # TODO
+    permutations = []
+
+    recurse = (keys, payload = {}, position = 0) ->
+      key = keys[position]
+
+      # There are no values for this attribute, skip it
+      if permutable_attributes[key].length is 0
+        if position < keys.length - 1
+          recurse keys, payload, position + 1
+        else
+          permutations.push _.clone payload
+
+      for value in permutable_attributes[key]
+        payload[key] = value
+
+        if position is keys.length - 1
+          permutations.push _.clone payload
+
+        else
+          recurse keys, payload, position + 1
+
+    recurse Object.keys permutable_attributes
+
+    return permutations

--- a/src/permutation/test/permutation-factory.spec.coffee
+++ b/src/permutation/test/permutation-factory.spec.coffee
@@ -9,7 +9,8 @@ describe 'permutationFactory:', ->
     permutationFactory = _permutationFactory_
 
   describe 'permute:', ->
-    expected_result = [
+    # Expected result for 2*2
+    result_2x2 = [
       name: 'foo'
       attr: 'biz'
     ,
@@ -23,14 +24,49 @@ describe 'permutationFactory:', ->
       attr: 'bat'
     ]
 
-    it 'Should generate 4 permutations from 2 properties with 2 values each.', ->
+    it 'Should generate 4 permutations from 2*2 attributes.', ->
       permutable_attributes =
         name: ['foo', 'bar']
         attr: ['biz', 'bat']
 
       permutations = permutationFactory.permute permutable_attributes
 
-      expect(permutations).toEqual expected_result
+      expect(permutations).toEqual result_2x2
+
+    it 'Should generate 6 permutations from 2*1*0*3 attributes.', ->
+      permutable_attributes =
+        name: ['foo', 'bar']
+        type: ['biz']
+        empty: []
+        desc: ['bing', 'bang', 'boom']
+
+      permutations = permutationFactory.permute permutable_attributes
+
+      expect(permutations).toEqual [
+        name: 'foo'
+        type: 'biz'
+        desc: 'bing'
+      ,
+        name: 'foo'
+        type: 'biz'
+        desc: 'bang'
+      ,
+        name: 'foo'
+        type: 'biz'
+        desc: 'boom'
+      ,
+        name: 'bar'
+        type: 'biz'
+        desc: 'bing'
+      ,
+        name: 'bar'
+        type: 'biz'
+        desc: 'bang'
+      ,
+        name: 'bar'
+        type: 'biz'
+        desc: 'boom'
+      ]
 
     it 'Should ignore attributes without any values.', ->
       permutable_attributes =
@@ -40,7 +76,7 @@ describe 'permutationFactory:', ->
 
       permutations = permutationFactory.permute permutable_attributes
 
-      expect(permutations).toEqual expected_result
+      expect(permutations).toEqual result_2x2
 
     it 'Should ignore empty attributes at the end of the object.', ->
       permutable_attributes =
@@ -50,7 +86,7 @@ describe 'permutationFactory:', ->
 
       permutations = permutationFactory.permute permutable_attributes
 
-      expect(permutations).toEqual expected_result
+      expect(permutations).toEqual result_2x2
 
     it 'Should invoke an optional callback for each permutation', ->
       callback = jasmine.createSpy 'callback'
@@ -64,4 +100,4 @@ describe 'permutationFactory:', ->
       expect(callback.calls.count()).toBe 4
 
       for i in [0..3]
-        expect(callback.calls.argsFor(i)).toEqual [expected_result[i]]
+        expect(callback.calls.argsFor(i)).toEqual [result_2x2[i]]

--- a/src/permutation/test/permutation-factory.spec.coffee
+++ b/src/permutation/test/permutation-factory.spec.coffee
@@ -42,6 +42,16 @@ describe 'permutationFactory:', ->
 
       expect(permutations).toEqual expected_result
 
+    it 'Should ignore empty attributes at the end of the object.', ->
+      permutable_attributes =
+        name: ['foo', 'bar']
+        attr: ['biz', 'bat']
+        empty: []
+
+      permutations = permutationFactory.permute permutable_attributes
+
+      expect(permutations).toEqual expected_result
+
     it 'Should invoke an optional callback for each permutation', ->
       callback = jasmine.createSpy 'callback'
 

--- a/src/permutation/test/permutation-factory.spec.coffee
+++ b/src/permutation/test/permutation-factory.spec.coffee
@@ -1,0 +1,57 @@
+describe 'permutationFactory:', ->
+  permutationFactory = null
+
+  beforeEach module 'app.permutation'
+
+  beforeEach inject (
+    _permutationFactory_
+  ) ->
+    permutationFactory = _permutationFactory_
+
+  describe 'permute:', ->
+    expected_result = [
+      name: 'foo'
+      attr: 'biz'
+    ,
+      name: 'foo'
+      attr: 'bat'
+    ,
+      name: 'bar'
+      attr: 'biz'
+    ,
+      name: 'bar'
+      attr: 'bat'
+    ]
+
+    it 'Should generate 4 permutations from 2 properties with 2 values each.', ->
+      permutable_attributes =
+        name: ['foo', 'bar']
+        attr: ['biz', 'bat']
+
+      permutations = permutationFactory.permute permutable_attributes
+
+      expect(permutations).toEqual expected_result
+
+    it 'Should ignore attributes without any values.', ->
+      permutable_attributes =
+        name: ['foo', 'bar']
+        empty: []
+        attr: ['biz', 'bat']
+
+      permutations = permutationFactory.permute permutable_attributes
+
+      expect(permutations).toEqual expected_result
+
+    it 'Should invoke an optional callback for each permutation', ->
+      callback = jasmine.createSpy 'callback'
+
+      permutable_attributes =
+        name: ['foo', 'bar']
+        attr: ['biz', 'bat']
+
+      permutations = permutationFactory.permute permutable_attributes, callback
+
+      expect(callback.calls.count()).toBe 4
+
+      for i in [0..3]
+        expect(callback.calls.argsFor(i)).toEqual [expected_result[i]]

--- a/src/widget/controller/widget-builder-controller.coffee
+++ b/src/widget/controller/widget-builder-controller.coffee
@@ -1,0 +1,15 @@
+angular.module 'app.widget'
+
+.controller 'WidgetBuilderController', (
+  $scope
+  $state
+  widgetStore
+) ->
+  $scope.submit = ($widgets) ->
+    console.log 'look at all these widgets we built!'
+    console.table $widgets
+
+    # Implement your AJAX call here
+    widgetStore.addWidgets $widgets
+
+    $state.go 'home'

--- a/src/widget/directive/widget-form-directive.coffee
+++ b/src/widget/directive/widget-form-directive.coffee
@@ -1,0 +1,46 @@
+###
+@name kcWidgetForm
+@description
+Form used to build permutations of widgets.
+
+@param {Callback} onSubmit
+
+@callback onSubmit
+@description
+Callback handler that decides what to do with the payload
+
+@param {Array} widgets - Collection of built widgets
+###
+
+angular.module 'app.widget'
+.directive 'kcWidgetForm', ->
+  restrict: 'E'
+  controller: 'KcWidgetFormController'
+  templateUrl: '/widget/widget-form.html'
+
+  scope:
+    onSubmit: '&onSubmit'
+
+.controller 'KcWidgetFormController', (
+  $scope
+) ->
+  $scope.state =
+    common_attributes:
+      permutation_group_name: ''
+
+    permutable_attributes:
+      name: []
+      thumbnail: []
+
+    widgets: []
+
+  $scope.buildPermutations = (permutable_attributes) ->
+    $scope.state.widgets =
+      widgetFactory.buildPermutations(
+        $scope.state.common_attributes
+        permutable_attributes
+      )
+
+  $scope.submit = ->
+    $scope.onSubmit
+      widgets: $scope.state.widgets

--- a/src/widget/directive/widget-form-directive.coffee
+++ b/src/widget/directive/widget-form-directive.coffee
@@ -33,10 +33,11 @@ angular.module 'app.widget'
       name: []
       description: []
 
-    widgets: []
+  # Collection of built widget permutations
+  $scope.widgets = []
 
   $scope.buildPermutations = (permutable_attributes) ->
-    $scope.state.widgets =
+    $scope.widgets =
       widgetFactory.buildPermutations(
         permutable_attributes
         $scope.state.common_attributes
@@ -44,4 +45,4 @@ angular.module 'app.widget'
 
   $scope.submit = ->
     $scope.onSubmit
-      $widgets: $scope.state.widgets
+      $widgets: $scope.widgets

--- a/src/widget/directive/widget-form-directive.coffee
+++ b/src/widget/directive/widget-form-directive.coffee
@@ -23,6 +23,7 @@ angular.module 'app.widget'
 
 .controller 'KcWidgetFormController', (
   $scope
+  widgetFactory
 ) ->
   $scope.state =
     common_attributes:
@@ -30,7 +31,7 @@ angular.module 'app.widget'
 
     permutable_attributes:
       name: []
-      thumbnail: []
+      description: []
 
     widgets: []
 

--- a/src/widget/directive/widget-form-directive.coffee
+++ b/src/widget/directive/widget-form-directive.coffee
@@ -38,10 +38,10 @@ angular.module 'app.widget'
   $scope.buildPermutations = (permutable_attributes) ->
     $scope.state.widgets =
       widgetFactory.buildPermutations(
-        $scope.state.common_attributes
         permutable_attributes
+        $scope.state.common_attributes
       )
 
   $scope.submit = ->
     $scope.onSubmit
-      widgets: $scope.state.widgets
+      $widgets: $scope.state.widgets

--- a/src/widget/model/widget-model.coffee
+++ b/src/widget/model/widget-model.coffee
@@ -2,4 +2,3 @@ angular.module 'app.widget'
 .factory 'Widget', ->
   class Widget
     constructor: (@attributes) ->
-      console.log 'new widget created', @attributes

--- a/src/widget/model/widget-model.coffee
+++ b/src/widget/model/widget-model.coffee
@@ -1,0 +1,5 @@
+angular.module 'app.widget'
+.factory 'Widget', ->
+  class Widget
+    constructor: (@attributes) ->
+      console.log 'new widget created', @attributes

--- a/src/widget/model/widget-model.coffee
+++ b/src/widget/model/widget-model.coffee
@@ -1,3 +1,4 @@
+# TODO: delete
 angular.module 'app.widget'
 .factory 'Widget', ->
   class Widget

--- a/src/widget/service/widget-factory.coffee
+++ b/src/widget/service/widget-factory.coffee
@@ -1,7 +1,7 @@
 ###
 @name widgetFactory
 @description
-Factory methods for building widgets.
+Where widgets get widgetized.
 ###
 
 angular.module 'app.widget'

--- a/src/widget/service/widget-factory.coffee
+++ b/src/widget/service/widget-factory.coffee
@@ -1,0 +1,41 @@
+###
+@name widgetFactory
+@description
+Factory methods for building widgets.
+###
+
+angular.module 'app.widget'
+.factory 'widgetFactory', (
+  permutationFactory
+  Widget
+) ->
+
+  build: (attributes) ->
+    # Right now you could perform some validation logic
+
+    return new Widget attributes
+
+  ###
+  @name buildPermutations
+  @description
+  Builds permutations of widgets.
+
+  @param {Object} permutable_attributes
+  @param {Object} common_attributes
+
+  @returns {Array.<Widget>} Collection of widgets
+  ###
+
+  buildPermutations: (permutable_attributes, common_attributes = {}) ->
+    throw Error 'Missing: permutable_attributes' unless permutable_attributes?
+
+    widgets = []
+
+    permutationFactory.permute permutable_attributes, (permutation) =>
+      # Extend common attributes onto each permutation
+      attributes = _.extend permutation, common_attributes
+
+      widgets.push @build attributes
+
+    return widgets
+

--- a/src/widget/service/widget-factory.coffee
+++ b/src/widget/service/widget-factory.coffee
@@ -11,9 +11,10 @@ angular.module 'app.widget'
 ) ->
 
   build: (attributes) ->
-    # Right now you could perform some validation logic
+    # Right now you could perform some validation logic,
+    # instantiate a model constructor, etc.
 
-    return new Widget attributes
+    return attributes
 
   ###
   @name buildPermutations

--- a/src/widget/service/widget-store.coffee
+++ b/src/widget/service/widget-store.coffee
@@ -1,0 +1,15 @@
+angular.module 'app.widget'
+.factory 'widgetStore', ->
+  widgets = [
+    name: 'Foowiz'
+    description: 'Descriptive description.'
+  ]
+
+  addWidgets: (new_widgets) ->
+    widgets = widgets.concat new_widgets
+
+  getWidgets: ->
+    return widgets
+
+  deleteWidget: (index) ->
+    widgets.splice index, 1

--- a/src/widget/test/widget-factory.spec.coffee
+++ b/src/widget/test/widget-factory.spec.coffee
@@ -27,13 +27,6 @@ describe 'widgetFactory:', ->
 
       widgets = widgetFactory.buildPermutations permutable_attributes
 
-    it 'Should return 4 widget model instances.', ->
-      expect(widgets.length).toBe 4
-
-      expect(
-        _.every widgets, (widget) -> return widget instanceof Widget
-      ).toBe true
-
     it 'Should call permutationFactory.permute with the correct arguments to generate permutations.', ->
       # Permutable attributes are first arg
       expect(
@@ -46,10 +39,7 @@ describe 'widgetFactory:', ->
       ).toBe 'function'
 
     it 'Should return 4 widgets with correct attributes.', ->
-      widget_attributes = _.map widgets, (widget) ->
-        return widget.attributes
-
-      expect(widget_attributes).toEqual [
+      expect(widgets).toEqual [
         name: 'foo'
         desc: 'biz'
       ,

--- a/src/widget/test/widget-factory.spec.coffee
+++ b/src/widget/test/widget-factory.spec.coffee
@@ -1,0 +1,64 @@
+describe 'widgetFactory:', ->
+  permutationFactory = null
+  Widget = null
+  widgetFactory = null
+
+  beforeEach module 'app.widget'
+
+  beforeEach inject (
+    _permutationFactory_
+    _Widget_
+    _widgetFactory_
+  ) ->
+    permutationFactory = _permutationFactory_
+    Widget = _Widget_
+    widgetFactory = _widgetFactory_
+
+  describe 'buildPermutations:', ->
+    widgets = null
+    permutable_attributes = null
+
+    beforeEach ->
+      spyOn(permutationFactory, 'permute').and.callThrough()
+
+      permutable_attributes =
+        name: ['foo', 'bar']
+        desc: ['biz', 'bat']
+
+      widgets = widgetFactory.buildPermutations permutable_attributes
+
+    it 'Should return 4 widget model instances.', ->
+      expect(widgets.length).toBe 4
+
+      expect(
+        _.every widgets, (widget) -> return widget instanceof Widget
+      ).toBe true
+
+    it 'Should call permutationFactory.permute with the correct arguments to generate permutations.', ->
+      # Permutable attributes are first arg
+      expect(
+        permutationFactory.permute.calls.mostRecent().args[0]
+      ).toEqual permutable_attributes
+
+      # Callback handler is second arg
+      expect(
+        typeof permutationFactory.permute.calls.mostRecent().args[1]
+      ).toBe 'function'
+
+    it 'Should return 4 widgets with correct attributes.', ->
+      widget_attributes = _.map widgets, (widget) ->
+        return widget.attributes
+
+      expect(widget_attributes).toEqual [
+        name: 'foo'
+        desc: 'biz'
+      ,
+        name: 'foo'
+        desc: 'bat'
+      ,
+        name: 'bar'
+        desc: 'biz'
+      ,
+        name: 'bar'
+        desc: 'bat'
+      ]

--- a/src/widget/widget-builder.jade
+++ b/src/widget/widget-builder.jade
@@ -1,0 +1,8 @@
+.container-fluid
+  .row
+    .col-md-12
+      p.lead Let's build some widgets.
+
+  kc-widget-form(
+    on-submit = "submit($widgets)"
+  )

--- a/src/widget/widget-form.jade
+++ b/src/widget/widget-form.jade
@@ -1,5 +1,5 @@
 div.row
-  .col-md-6
+  .col-lg-6.col-md-8.col-sm-6
     kc-permutable-attributes(
       permutable-attributes = "state.permutable_attributes"
       build-permutations = "buildPermutations(permutable_attributes)"
@@ -15,7 +15,7 @@ div.row
         type = "text"
       ) Description
 
-  .col-md-5.col-md-offset-1
+  .col-lg-4.col-md-4.col-sm-6
     .well
       h4 {{widgets.length}} Widgets Built
 

--- a/src/widget/widget-form.jade
+++ b/src/widget/widget-form.jade
@@ -17,7 +17,7 @@ div.row
 
   .col-md-5.col-md-offset-1
     .well
-      h4 {{state.widgets.length}} Widgets Built
+      h4 {{widgets.length}} Widgets Built
 
       h5 Name ({{state.permutable_attributes.name.length}})
       ul.list-unstyled
@@ -31,9 +31,8 @@ div.row
           ng-repeat = "description in state.permutable_attributes.description"
         ) {{description}}
 
-
-
       button.btn.btn-default(
         type = "button"
         ng-click = "submit()"
+        ng-disabled = "widgets.length === 0"
       ) Submit

--- a/src/widget/widget-form.jade
+++ b/src/widget/widget-form.jade
@@ -1,0 +1,35 @@
+form.row(
+  name = "forms.widget"
+  ng-submit = "submit()"
+)
+  .col-md-6
+    .form-group
+      label Permutation Group Name
+      input.form-control(
+        type = "text"
+        name = "permutation_group_name"
+        ng-model = "state.common_attributes.permutation_group_name"
+      )
+
+    kc-permutable-attributes(
+      permutable-attributes = "state.permutable_attributes"
+      build-permutations = "buildPermutations(permutable_attributes)"
+    )
+      kc-permutable-input(
+        name = "name"
+        type = "text"
+        required
+      ) Name
+
+      kc-permutable-image(
+        name = "thumbnail"
+        type = "image"
+      ) Thumbnail
+
+  .col-md-4.col-md-offset-2
+    .well
+      h2 0 Widgets Built
+
+      button(
+        type = "submit"
+      ) Submit

--- a/src/widget/widget-form.jade
+++ b/src/widget/widget-form.jade
@@ -1,16 +1,5 @@
-form.row(
-  name = "forms.widget"
-  ng-submit = "submit()"
-)
+div.row
   .col-md-6
-    .form-group
-      label Permutation Group Name
-      input.form-control(
-        type = "text"
-        name = "permutation_group_name"
-        ng-model = "state.common_attributes.permutation_group_name"
-      )
-
     kc-permutable-attributes(
       permutable-attributes = "state.permutable_attributes"
       build-permutations = "buildPermutations(permutable_attributes)"
@@ -21,15 +10,30 @@ form.row(
         required
       ) Name
 
-      kc-permutable-image(
-        name = "thumbnail"
-        type = "image"
-      ) Thumbnail
+      kc-permutable-input(
+        name = "description"
+        type = "text"
+      ) Description
 
-  .col-md-4.col-md-offset-2
+  .col-md-5.col-md-offset-1
     .well
-      h2 0 Widgets Built
+      h4 {{state.widgets.length}} Widgets Built
 
-      button(
-        type = "submit"
+      h5 Name ({{state.permutable_attributes.name.length}})
+      ul.list-unstyled
+        li(
+          ng-repeat = "name in state.permutable_attributes.name"
+        ) {{name}}
+
+      h5 Description ({{state.permutable_attributes.description.length}})
+      ul.list-unstyled
+        li(
+          ng-repeat = "description in state.permutable_attributes.description"
+        ) {{description}}
+
+
+
+      button.btn.btn-default(
+        type = "button"
+        ng-submit = "submit()"
       ) Submit

--- a/src/widget/widget-form.jade
+++ b/src/widget/widget-form.jade
@@ -35,5 +35,5 @@ div.row
 
       button.btn.btn-default(
         type = "button"
-        ng-submit = "submit()"
+        ng-click = "submit()"
       ) Submit

--- a/src/widget/widget.coffee
+++ b/src/widget/widget.coffee
@@ -1,3 +1,14 @@
 angular.module 'app.widget', [
   'app.permutation'
+  'ui.router'
 ]
+
+.config (
+  $stateProvider
+) ->
+  $stateProvider.state 'widget-builder',
+    url: '/widget-builder'
+    views:
+      'main':
+        controller: 'WidgetBuilderController'
+        templateUrl: '/widget/widget-builder.html'

--- a/src/widget/widget.coffee
+++ b/src/widget/widget.coffee
@@ -1,0 +1,3 @@
+angular.module 'app.widget', [
+  'app.permutation'
+]

--- a/styles/_layout.scss
+++ b/styles/_layout.scss
@@ -2,3 +2,9 @@
 body {
   padding-top: 70px;
 }
+
+@media (max-width: $screen-xs-max) {
+  body {
+    padding-top: 167px;
+  }
+}

--- a/styles/_layout.scss
+++ b/styles/_layout.scss
@@ -1,1 +1,4 @@
 // Add layout styles here
+body {
+  padding-top: 70px;
+}


### PR DESCRIPTION
This PR adds

Permutation module:
- `kcPermutableAttributes`
- `kcPermutableInput`
- `kcPermutableImage`
- `permutationFactory` used to generate permutations

Widget module:
- `kcWidgetForm` directive for building widget permutations
- `widgetFactory` for building widget models
- `widgetStore` for storing widget models
- Consumes common directives in permutation module
