### PR TITLE
chore(gulp): fix sass precision for twitter bootstrap

### DIFF
--- a/lib/gulp/sass.coffee
+++ b/lib/gulp/sass.coffee
@@ -8,7 +8,12 @@ includePaths = [
 module.exports = (gulp) ->
   gulp.task 'sass:dev', ->
     return gulp.src 'styles/**/*.scss'
-      .pipe sass {includePaths}
+      .pipe sass
+        includePaths: includePaths
+        # Minimum precision of 8 decimal points required for bootstrap.
+        # See https://github.com/twbs/bootstrap-sass#sass-number-precision
+        precision: 8
+
       .pipe gulp.dest 'build/css'
 
   gulp.task 'sass:dist', ->
@@ -16,6 +21,7 @@ module.exports = (gulp) ->
       .pipe sass
         includePaths: includePaths
         outputStyle: 'compressed'
+        precision: 8
 
       .pipe gulp.dest 'dist/css'
 


### PR DESCRIPTION
Fixes broken alignment of Twitter Bootstrap components. See See https://github.com/twbs/bootstrap-sass#sass-number-precision
